### PR TITLE
Fix typo 'abandonned'

### DIFF
--- a/gestion/src/Main/CommonBundle/Resources/translations/email.fr.yml
+++ b/gestion/src/Main/CommonBundle/Resources/translations/email.fr.yml
@@ -92,7 +92,7 @@ prestation:
             p2: p2 à venir
             panel: panel à venir
             text: Votre espace    
-    abandonned:
+    abandoned:
         client:
             subject: Votre demande a bien été abandonée
             p_lead %reference%: La demande %reference% a bien été abandonnée

--- a/gestion/src/Main/CommonBundle/Resources/views/Emails/Prestations/Abandonned/to_client.html.twig
+++ b/gestion/src/Main/CommonBundle/Resources/views/Emails/Prestations/Abandonned/to_client.html.twig
@@ -1,25 +1,25 @@
 {% embed "MainCommonBundle:Emails:email.html.twig" %}
 		{% block h1 %}{{ prestation.client.username }},{% endblock %}
 		{% block p_lead %}
-			{% trans with{'%reference%' : prestation.reference} from "email" %}prestation.abandonned.client.p_lead %reference%
+			{% trans with{'%reference%' : prestation.reference} from "email" %}prestation.abandoned.client.p_lead %reference%
 			{% endtrans %}
 		{% endblock %}
 		{% block p1 %}
 			{% trans with {'%date%': prestation.updatedAt|date('d/m/Y'), 
-			'%heure%': prestation.updatedAt|date('H:i')} from "email" %}prestation.abandonned.client.p1 %date% %heure%
+			'%heure%': prestation.updatedAt|date('H:i')} from "email" %}prestation.abandoned.client.p1 %date% %heure%
 			{% endtrans %}
 		{% endblock %}
 		{% block p2 %}
-			{% trans from "email" %}prestation.abandonned.client.p2
+			{% trans from "email" %}prestation.abandoned.client.p2
 			{% endtrans %}
 		{% endblock %}
 		{% block panel %}
-			{% trans from "email" %}prestation.abandonned.client.panel
+			{% trans from "email" %}prestation.abandoned.client.panel
 			{% endtrans %}
 		{% endblock %}
 		{% block link %}{{ base_url}}/{% endblock %}
 		{% block text %}
-			{% trans from "email" %}prestation.abandonned.client.text
+			{% trans from "email" %}prestation.abandoned.client.text
 			{% endtrans %}
 		{% endblock %}
 

--- a/gestion/src/Main/CommonBundle/Resources/views/Emails/Prestations/Abandonned/to_photographer.html.twig
+++ b/gestion/src/Main/CommonBundle/Resources/views/Emails/Prestations/Abandonned/to_photographer.html.twig
@@ -1,20 +1,20 @@
 {% embed "MainCommonBundle:Emails:email.html.twig" %}
 		{% block h1 %}{{ prestation.devis.company.photographer.username }},{% endblock %}
 		{% block p_lead %}
-			{% trans with{'%reference%' : prestation.reference} from "email" %}prestation.abandonned.photographer.p_lead %reference%
+			{% trans with{'%reference%' : prestation.reference} from "email" %}prestation.abandoned.photographer.p_lead %reference%
 			{% endtrans %}
 		{% endblock %}
 		{% block p1 %}
-			{% trans from "email" %}prestation.abandonned.photographer.p1
+			{% trans from "email" %}prestation.abandoned.photographer.p1
 			{% endtrans %}
 		{% endblock %}
 		{% block panel %}
-			{% trans from "email" %}prestation.abandonned.photographer.panel
+			{% trans from "email" %}prestation.abandoned.photographer.panel
 			{% endtrans %}
 		{% endblock %}
 		{% block link %}{{ base_url}}/{% endblock %}
 		{% block text %}
-			{% trans from "email" %}prestation.abandonned.photographer.text
+			{% trans from "email" %}prestation.abandoned.photographer.text
 			{% endtrans %}
 		{% endblock %}
 

--- a/gestion/src/Main/CommonBundle/Services/Emails/ServiceEmail.php
+++ b/gestion/src/Main/CommonBundle/Services/Emails/ServiceEmail.php
@@ -104,8 +104,8 @@ class ServiceEmail
             //Cancel-Client
                 $templatePhotographer = 'MainCommonBundle:Emails\Prestations\Abandonned:to_photographer.html.twig';
                 $templateClient = 'MainCommonBundle:Emails\Prestations\Abandonned:to_client.html.twig';
-                $subjectPhotographer = $this->translator->trans('prestation.abandonned.photographer.subject', array(), 'email');
-                $subjectClient = $this->translator->trans('prestation.abandonned.client.subject', array(), 'email');
+                $subjectPhotographer = $this->translator->trans('prestation.abandoned.photographer.subject', array(), 'email');
+                $subjectClient = $this->translator->trans('prestation.abandoned.client.subject', array(), 'email');
                 break;
             case 5:
             //Valide


### PR DESCRIPTION

Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'abandoned', you typed 'abandonned'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
            